### PR TITLE
Adds id while keeping named anchor

### DIFF
--- a/anchors/services/AnchorsService.php
+++ b/anchors/services/AnchorsService.php
@@ -122,7 +122,7 @@ class AnchorsService extends BaseApplicationComponent
 		$heading = strip_tags(str_replace(array('&nbsp;', ' '), ' ', $match[3]));
 
 		return '<a'.($this->anchorClass ? ' class="'.$this->anchorClass.'"' : '').' name="'.$anchorName.'"></a>' .
-			'<'.$match[1].$match[2].'>' .
+			'<'.$match[1].$match[2].' id="'.$anchorName.'">' .
 			$match[3] .
 			' <a'.($this->anchorLinkClass ? ' class="'.$this->anchorLinkClass.'"' : '').' href="#'.$anchorName.'" title="'.Craft::t($this->anchorLinkTitleText, array('heading' => $heading)).'">'.$this->anchorLinkText.'</a>' .
 			'</'.$match[1].'>';


### PR DESCRIPTION
### Expected

While using JS animated scrolling library, after applying Twig filter, the anchor that follows the header will link directly to the header.

![demo-anchor-working](https://user-images.githubusercontent.com/1581276/38327331-cfafca1a-37fc-11e8-8267-e664a80a308c.gif)

### Actual

After applying Twig filter, markup is correctly updated, but anchor links don’t work.

![demo-anchor-not-working](https://user-images.githubusercontent.com/1581276/38327337-d2689714-37fc-11e8-921d-6fef29f2a347.gif)

***

Some frequently used JS libraries that support smooth scrolling between `id`s, and I am more familiar with this approach:

```html
<h1 id="link-to-me">Link to me</h1>
```

But not named anchors:

```html
<h1><a name="link-to-me"></a>Link to me</h1>
```

- [smooth-scroll](https://www.npmjs.com/package/smooth-scroll)
- [smoothscroll](https://www.npmjs.com/package/smoothscroll)

After looking into the reason, apparently anchors with names might not be considered a valid attribute on anchors in HTML5? #4 There’s a discussion about all of this on [this Stack Overflow question](https://stackoverflow.com/questions/484719/html-anchors-with-name-or-id).

I don’t necessarily think it’s a good idea to change the markup to match some JS libraries, but I do also think `id` is a more common convention than named anchors now.

To keep this from being a breaking change, I didn’t remove the named anchor and just added the `id`, but I think it would be better to remove the named anchor as well.

Alternatively, I could add a new option that lets you choose `id`s instead of named anchors?

If you are fine with one of these changes, I can update the PR, and open it on the v2 branch as well. Thanks either way!