### PR TITLE
Allow anchorLinkText to use {heading} variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following config settings are supported:
 
 - `anchorClass` – The class name that should be given to named anchors. (Default is `null`, meaning no class will be given.)
 - `anchorLinkClass` – The class name that should be given to anchor links. (Default is `'anchor'`.)
-- `anchorLinkText` – The visible text that anchor links should have. (Default is `'#'`'.)
+- `anchorLinkText` – The visible text that anchor links should have. (Default is `'#'`'. If `{heading}` is included, it will be replaced with the heading text the link is associated with.)
 - `anchorLinkTitleText` – The title/alt text that anchor links should have. If `{heading}` is included, it will be replaced with the heading text the link is associated with. (Default is `'Direct link to {heading}'`.)
 
 ## Plugin API

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -62,7 +62,7 @@ class Parser extends Component
             return '<a'.($this->anchorClass ? ' class="'.$this->anchorClass.'"' : '').' id="'.$anchorName.'"></a>'.
                 '<'.$match[1].$match[2].'>'.
                 $match[3].
-                ' <a'.($this->anchorLinkClass ? ' class="'.$this->anchorLinkClass.'"' : '').' href="#'.$anchorName.'" title="'.Craft::t('anchors', $this->anchorLinkTitleText, ['heading' => $heading]).'">'.$this->anchorLinkText.'</a>'.
+                ' <a'.($this->anchorLinkClass ? ' class="'.$this->anchorLinkClass.'"' : '').' href="#'.$anchorName.'" title="'.Craft::t('anchors', $this->anchorLinkTitleText, ['heading' => $heading]).'">'.Craft::t('anchors', $this->anchorLinkText, ['heading' => $heading]).'</a>'.
                 '</'.$match[1].'>';
         }, $html);
     }


### PR DESCRIPTION
I'm attempting to use Anchors to generate a subnavigation on my site using h1, h2, h3 elements.  Anchors is really close to allowing me to do so, but is limiting in where I can use the {heading} variable—only in title text, which makes sense for anchor links.

While I can't see an "anchor" use case for this necessarily, it doesn't seem harmful to allow flexibility in where that variable can be used.