### PR TITLE
Added a new feature "$anchorLink"

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ To configure Anchors, create a new `anchors.php` file within the `config/` folde
 The following config settings are supported:
 
 - `anchorClass` – The class name that should be given to named anchors. (Default is `null`, meaning no class will be given.)
+- `anchorLink` – The "a" tag if you don't want a url and only inside the h-tag the anchor name. (Default is `true`, meaning the link is created.)
 - `anchorLinkPosition` – The position that anchor links should have within headings, relative to the heading text (`'before'` or `'after'`). (Default is `'after'`.)
 - `anchorLinkClass` – The class name that should be given to anchor links. (Default is `'anchor'`.)
 - `anchorLinkText` – The visible text that anchor links should have. (Default is `'#'`'.)

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -23,11 +23,11 @@ class Parser extends Component
      * @var string|null
      */
     public $anchorClass;
-    
-     /**
+
+    /**
      * @var bool
      */
-    public $anchorClass = true;
+    public $anchorLink;
 
     /**
      * @var string Where the anchor link should be positioned within the heading, relative to the heading text (`before` or `after`)
@@ -70,27 +70,26 @@ class Parser extends Component
         return preg_replace_callback('/<(' . implode('|', $tags) . ')([^>]*)>(.+?)<\/\1>/', function(array $match) use ($language) {
             $anchorName = $this->generateAnchorName($match[3], $language);
             $heading = strip_tags(str_replace(['&nbsp;', ' '], ' ', $match[3]));
-            $link = Html::tag('a', $this->anchorLinkText, [
-                'class' => $this->anchorLinkClass,
-                'title' => Craft::t('anchors', $this->anchorLinkTitleText, ['heading' => $heading]),
-                'href' => "#$anchorName",
-            ]);
-            
+
             if($this->anchorLink === true){
+                $link = Html::tag('a', $this->anchorLinkText, [
+                    'class' => $this->anchorLinkClass,
+                    'title' => Craft::t('anchors', $this->anchorLinkTitleText, ['heading' => $heading]),
+                    'href' => "#$anchorName",
+                ]);
+
                 return Html::a('', null, [
-                    'class' => $this->anchorClass,
-                    'id' => $anchorName,
-                ]).
-                    "<$match[1]$match[2]>".
+                        'class' => $this->anchorClass,
+                        'id' => $anchorName,
+                    ]) .
+                    "<$match[1]$match[2]>" .
                     ($this->anchorLinkPosition === Settings::POS_BEFORE ? "$link $match[3]" : "$match[3] $link") .
-                "</$match[1]>";
+                    "</$match[1]>";
             }
 
-                return "<$match[1]$match[2] id=\"$anchorName\">".
-                    $match[3].
-                    "</$match[1]>";
-
-              
+            return "<$match[1]$match[2] id=\"$anchorName\">" .
+                $match[3] .
+                "</$match[1]>";
 
         }, $html);
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -23,6 +23,11 @@ class Parser extends Component
      * @var string|null
      */
     public $anchorClass;
+    
+     /**
+     * @var bool
+     */
+    public $anchorClass = true;
 
     /**
      * @var string Where the anchor link should be positioned within the heading, relative to the heading text (`before` or `after`)
@@ -70,15 +75,23 @@ class Parser extends Component
                 'title' => Craft::t('anchors', $this->anchorLinkTitleText, ['heading' => $heading]),
                 'href' => "#$anchorName",
             ]);
-
-            return
-                Html::a('', null, [
+            
+            if($this->anchorLink === true){
+                return Html::a('', null, [
                     'class' => $this->anchorClass,
                     'id' => $anchorName,
-                ]) .
-                "<$match[1]$match[2]>" .
-                ($this->anchorLinkPosition === Settings::POS_BEFORE ? "$link $match[3]" : "$match[3] $link") .
+                ]).
+                    "<$match[1]$match[2]>".
+                    ($this->anchorLinkPosition === Settings::POS_BEFORE ? "$link $match[3]" : "$match[3] $link") .
                 "</$match[1]>";
+            }
+
+                return "<$match[1]$match[2] id=\"$anchorName\">".
+                    $match[3].
+                    "</$match[1]>";
+
+              
+
         }, $html);
     }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -35,6 +35,7 @@ class Plugin extends \craft\base\Plugin
         $this->set('parser', [
             'class' => Parser::class,
             'anchorClass' => $settings->anchorClass,
+            'anchorLink' => $settings->anchorLink,
             'anchorLinkPosition' => $settings->anchorLinkPosition,
             'anchorLinkClass' => $settings->anchorLinkClass,
             'anchorLinkText' => $settings->anchorLinkText,

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -22,6 +22,12 @@ class Settings extends Model
      * (Default is null, meaning no class will be given.)
      */
     public $anchorClass;
+    
+     /**
+     * @var bool If true then it uses "a" tags if not then it creates only id attribute inside h tag.
+     * (Default is true.)
+     */
+    public $anchorLink = true;
 
     /**
      * @var string Where the anchor link should be positioned within the heading, relative to the heading text (`before` or `after`)
@@ -29,12 +35,12 @@ class Settings extends Model
      */
     public $anchorLinkPosition = self::POS_AFTER;
 
-    /**
+        /**
      * @var string The class name that should be given to anchor links.
      * (Default is 'anchor'.)
      */
     public $anchorLinkClass = 'anchor';
-
+    
     /**
      * @var string The visible text that anchor links should have.
      * (Default is '#'.)


### PR DESCRIPTION
### Description
I added a new feature to check if you want use anchor links or the anchor name directly inside the h-tag by default the behaviour its like before you need to set to the config file `'anchorLink' => false` to see what happens.

I updated the readme file too and added the new feature.

I need this feature because of SEO in this case it's better to use  it like this in my case.