### PR TITLE
remove new lines from headings html

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -62,6 +62,9 @@ class Parser extends Component
             $tags = StringHelper::split($tags);
         }
 
+        // https://github.com/craftcms/anchors/issues/20 => remove new lines from headings
+        $html = preg_replace(['/\>\s+/', '/\s+<\//', '/\s/'], ['>', '</', ' '], $html);
+
         return preg_replace_callback('/<(' . implode('|', $tags) . ')([^>]*)>(.+?)<\/\1>/', function(array $match) use ($language) {
             $anchorName = $this->generateAnchorName($match[3], $language);
             $heading = strip_tags(str_replace(['&nbsp;', ' '], ' ', $match[3]));


### PR DESCRIPTION
### Description
Remove new lines from `$html` so that anchors can be created and applied in cases like 
```
{% apply anchors('h2') %}
  <h2>
    Hello
  </h2>
{% endapply %}
```

The issue affects both `v2` and `main`. The same commit can be applied to `main` too.

### Related issues
#20 
