### PR TITLE
accessibility improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes for Anchors
 
 ## Unreleased
+- Removed unnecessary tab spots. ([#21](https://github.com/craftcms/anchors/issues/21))
 - Fixed a bug where headings that spanned multiple lines were ignored. ([#20](https://github.com/craftcms/anchors/issues/20))
 
 ## 2.3.1 - 2022-02-25

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -73,7 +73,7 @@ class Parser extends Component
             ]);
 
             return
-                Html::tag('span', null, [
+                Html::tag('span', '', [
                     'class' => $this->anchorClass,
                     'id' => $anchorName,
                 ]) .

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -68,11 +68,12 @@ class Parser extends Component
             $link = Html::tag('a', $this->anchorLinkText, [
                 'class' => $this->anchorLinkClass,
                 'title' => Craft::t('anchors', $this->anchorLinkTitleText, ['heading' => $heading]),
+                'aria-label' => Craft::t('anchors', $this->anchorLinkTitleText, ['heading' => $heading]),
                 'href' => "#$anchorName",
             ]);
 
             return
-                Html::a('', null, [
+                Html::tag('span', null, [
                     'class' => $this->anchorClass,
                     'id' => $anchorName,
                 ]) .


### PR DESCRIPTION
### Description
Added the `aria-label` attribute to the anchor link.
Changed tag added above the heading from anchor to span to improve the experience when tabbing through the page with the keyboard

The issue affects both `v2` and `main`. The same commit can be applied to the `main` too.

### Related issues
#21 
