### PR TITLE
new useAdditionalTagToAnchorTo config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for Anchors
 
+## Unreleased
+- Added the `useAdditionalTagToAnchorTo` config option which allows you to opt out of a tag being added and used to link to, in favour of using heading's id. ([#21](https://github.com/craftcms/anchors/issues/21))
+
 ## 3.2.0 - 2023-01-09
 - Added the `@anchors` GraphQL directive. ([#18](https://github.com/craftcms/anchors/issues/18))
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following config settings are supported:
 - `anchorLinkClass` – The class name that should be given to anchor links. (Default is `'anchor'`.)
 - `anchorLinkText` – The visible text that anchor links should have. (Default is `'#'`'.)
 - `anchorLinkTitleText` – The title/alt text that anchor links should have. If `{heading}` is included, it will be replaced with the heading text the link is associated with. (Default is `'Direct link to {heading}'`.)
+- `useAdditionalTagToAnchorTo` – Whether to render an additional tag above the heading and use it to scroll to when the anchor link is clicked. If set to `false`, anchor id is added to the heading. (Default is `true`.)
 
 ## Plugin API
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -45,6 +45,12 @@ class Parser extends Component
      */
     public $anchorLinkTitleText;
 
+    /**
+     * @var bool|null
+     * @since 3.3.0
+     */
+    public $useAdditionalTagToAnchorTo;
+
     // Public Methods
     // =========================================================================
 
@@ -63,7 +69,18 @@ class Parser extends Component
         }
 
         return preg_replace_callback('/<(' . implode('|', $tags) . ')([^>]*)>\s*([\w\W]+?)\s*<\/\1>/', function(array $match) use ($language) {
-            $anchorName = $this->generateAnchorName($match[3], $language);
+            $headingHasId = false;
+            // try to get id from the heading tag only if we're not supposed to use additional tag to anchor to
+            if (!$this->useAdditionalTagToAnchorTo && !empty($match[2])) {
+                $anchorName = $this->getIdFromHeading($match[2]);
+                if (!empty($anchorName)) {
+                    $headingHasId = true;
+                }
+            }
+            // if we still don't have the name for the anchor - generate it
+            if (empty($anchorName)) {
+                $anchorName = $this->generateAnchorName($match[3], $language);
+            }
             $heading = preg_replace('/\s+/', ' ', strip_tags(str_replace(['&nbsp;', ' '], ' ', $match[3])));
             $link = Html::tag('a', $this->anchorLinkText, [
                 'class' => $this->anchorLinkClass,
@@ -73,11 +90,12 @@ class Parser extends Component
             ]);
 
             return
-                Html::tag('span', '', [
-                    'class' => $this->anchorClass,
-                    'id' => $anchorName,
-                ]) .
-                "<$match[1]$match[2]>" .
+                ($this->useAdditionalTagToAnchorTo ?
+                    Html::tag('span', '', [
+                        'class' => $this->anchorClass,
+                        'id' => $anchorName,
+                    ]) : '') .
+                "<$match[1]$match[2]" . (!$this->useAdditionalTagToAnchorTo && !$headingHasId ? " id=\"$anchorName\"" : "") . ">" .
                 ($this->anchorLinkPosition === Settings::POS_BEFORE ? "$link $match[3]" : "$match[3] $link") .
                 "</$match[1]>";
         }, $html);
@@ -120,5 +138,23 @@ class Parser extends Component
 
         // Put them together as the anchor name
         return StringHelper::toAscii(implode('-', $words), $language);
+    }
+
+    /**
+     * Check if there's an id in the attributes. If there is one - return its value.
+     *
+     * @param $attributes
+     * @return string|null
+     */
+    public function getIdFromHeading($attributes): ?string
+    {
+        $id = null;
+        preg_match('/id="(\w+)"/', $attributes, $match);
+
+        if (isset($match[1]) && !empty($match[1])) {
+            $id = trim($match[1]);
+        }
+
+        return $id;
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -48,6 +48,7 @@ class Plugin extends \craft\base\Plugin
         $parser->anchorLinkClass = $parser->anchorLinkClass ?? $settings->anchorLinkClass;
         $parser->anchorLinkText = $parser->anchorLinkText ?? $settings->anchorLinkText;
         $parser->anchorLinkTitleText = $parser->anchorLinkTitleText ?? $settings->anchorLinkTitleText;
+        $parser->useAdditionalTagToAnchorTo = $parser->useAdditionalTagToAnchorTo ?? $settings->useAdditionalTagToAnchorTo;
 
         if (!Craft::$app->getRequest()->getIsCpRequest()) {
             // Register the Twig extension

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -47,4 +47,13 @@ class Settings extends Model
      * the link is associated with. (Default is 'Direct link to {heading}'.)
      */
     public $anchorLinkTitleText = 'Direct link to {heading}';
+
+    /**
+     * @var bool Whether to render an additional tag above the heading
+     * and use it to scroll to when the anchor link is clicked.
+     * If set to 'false', anchor id is added to the heading itself.
+     * (Default is 'true'.)
+     * @since 3.3.0
+     */
+    public $useAdditionalTagToAnchorTo = true;
 }


### PR DESCRIPTION
### Description
This PR adds a new `useAdditionalTagToAnchorTo` config setting that defaults to `true` (same as the current behaviour). 
If it’s set to `false`, the `id` will be added to the heading tag (or if one is already present, it will be used), and the anchor link will link to the heading itself.


### Related issues
#21 
