### PR TITLE
Bugfix/31 anchor name formatting amends

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ If you are displaying content in a different language than the current site, use
 {{ entry.body|anchors(language=entry.site.language) }}
 ```
 
+By default, `anchors` filter will lowercase words that are all uppercase and lowercase the first letter in any other case.
+
+If you want the anchors to always be lowercase, you can use the `lowercase` argument:
+
+```twig
+{{ entry.body|anchors(lowercase=true) }}
+```
+
 ## Configuration
 
 To configure Anchors, create a new `anchors.php` file within the `config/` folder, which returns an array.

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -54,16 +54,17 @@ class Parser extends Component
      * @param string $html The HTML to parse
      * @param string|string[] $tags The tags to add anchor links to.
      * @param string|null $language The content language, used when converting non-ASCII characters to ASCII
+     * @param bool $lowercase Whether to always lowercase the entire anchor name
      * @return string The parsed HTML.
      */
-    public function parseHtml(string $html, $tags = 'h1,h2,h3', ?string $language = null): string
+    public function parseHtml(string $html, $tags = 'h1,h2,h3', ?string $language = null, bool $lowercase = false): string
     {
         if (is_string($tags)) {
             $tags = StringHelper::split($tags);
         }
 
-        return preg_replace_callback('/<(' . implode('|', $tags) . ')([^>]*)>\s*([\w\W]+?)\s*<\/\1>/', function(array $match) use ($language) {
-            $anchorName = $this->generateAnchorName($match[3], $language);
+        return preg_replace_callback('/<(' . implode('|', $tags) . ')([^>]*)>\s*([\w\W]+?)\s*<\/\1>/', function(array $match) use ($language, $lowercase) {
+            $anchorName = $this->generateAnchorName($match[3], $language, $lowercase);
             $heading = preg_replace('/\s+/', ' ', strip_tags(str_replace(['&nbsp;', ' '], ' ', $match[3])));
             $link = Html::tag('a', $this->anchorLinkText, [
                 'class' => $this->anchorLinkClass,
@@ -88,9 +89,10 @@ class Parser extends Component
      *
      * @param string $heading
      * @param string|null $language
+     * @param bool $lowercase
      * @return string The generated anchor name.
      */
-    public function generateAnchorName(string $heading, string $language = null): string
+    public function generateAnchorName(string $heading, string $language = null, bool $lowercase = false): string
     {
         // decode html entities into chars
         // see https://github.com/craftcms/anchors/issues/31 for details
@@ -114,11 +116,15 @@ class Parser extends Component
 
         // Turn them into camelCase
         foreach ($words as $i => $word) {
-            // Special case if the whole word is capitalized
-            if (strtoupper($word) === $word) {
+            if ($lowercase === true) {
                 $words[$i] = strtolower($word);
             } else {
-                $words[$i] = lcfirst($word);
+                // Special case if the whole word is capitalized
+                if (strtoupper($word) === $word) {
+                    $words[$i] = strtolower($word);
+                } else {
+                    $words[$i] = lcfirst($word);
+                }
             }
         }
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -92,6 +92,10 @@ class Parser extends Component
      */
     public function generateAnchorName(string $heading, string $language = null): string
     {
+        // decode html entities into chars
+        // see https://github.com/craftcms/anchors/issues/31 for details
+        $heading = htmlspecialchars_decode($heading, ENT_QUOTES);
+
         // Remove HTML tags
         $heading = preg_replace('/<(.*?)>/', '', $heading);
 

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -40,10 +40,11 @@ class TwigExtension extends \Twig_Extension
      * @param mixed $html The HTML to parse.
      * @param string|string[] $tags The HTML tags to check for.
      * @param string|null $language The content language, used when converting non-ASCII characters to ASCII
+     * @param bool $lowercase Whether to always lowercase the entire anchor name
      * @return string The parsed string.
      */
-    public function anchorsFilter($html, $tags = 'h1,h2,h3', ?string $language = null): string
+    public function anchorsFilter($html, $tags = 'h1,h2,h3', ?string $language = null, bool $lowercase = false): string
     {
-        return Plugin::getInstance()->getParser()->parseHtml((string)$html, $tags, $language);
+        return Plugin::getInstance()->getParser()->parseHtml((string)$html, $tags, $language, $lowercase);
     }
 }


### PR DESCRIPTION
### Description
1. Adds decoding of special chars before generating anchor names.

**Example:**
```
{{ tag('h2', {
    text: "We'd love to hear from you",
})|anchors }}
```
was producing an anchor of: `we-039-d-love-to-hear-from-you`, while `{% apply anchors() %}` and `|anchors` were producing: `wed-love-to-hear-from-you`. 

Now all 3 options produce: `wed-love-to-hear-from-you`.

2. Adds `lowercase` attribute, which defaults to `false` and produces the same behaviour as before. If set to `true`, it ensures that the entire anchor is lowercase.
The default behaviour stays as is: lowercase words that are all uppercase and lowercase the first letter in any other case.

**Example:**
```
{% apply anchors('h2') %}
    <h2>Pitch FAQs</h2>
{% endapply %}
```
still produces: `pitch-fAQs`
```
{% apply anchors('h2', lowercase=true) %}
    <h2>Pitch FAQs</h2>
{% endapply %}
```
produces: `pitch-faqs`

Applies to v2 and v3.

@brandonkelly if you think point 2 is not something we should pursue or it should be changed to a configuration setting, please let me know, and I’ll adjust. I’m thinking this version gives the best flexibility.

### Related issues
#31 
